### PR TITLE
Fix type declaration for curl_write_callback

### DIFF
--- a/file-updater.c
+++ b/file-updater.c
@@ -47,10 +47,11 @@ void update_info_destroy(struct update_info *info)
 	bfree(info);
 }
 
-static size_t http_write(uint8_t *ptr, size_t size, size_t nmemb,
-			 struct update_info *info)
+static size_t http_write(void *ptr, size_t size, size_t nmemb, void *uinfo)
 {
 	size_t total = size * nmemb;
+	struct update_info *info = (struct update_info *)uinfo;
+
 	if (total)
 		da_push_back_array(info->file_data, ptr, total);
 


### PR DESCRIPTION
`CURLOPT_WRITEFUNCTION` has an argument signature of `(void, size_t, size_t, void)` so having a different signature will cause compiler errors with stricter settings (e.g., with LTO being on and with all warnings being treated as errors).

This makes the CURL write callback function follow the signature of CURLOPT_WRITEFUNCTION to prevent this.

Sample compilation output:
```
[  6%] Automatic MOC and UIC for target vertical-canvas
[  6%] Built target vertical-canvas_autogen
[ 13%] Automatic RCC for resources.qrc
[ 33%] Building CXX object CMakeFiles/vertical-canvas.dir/source-tree.cpp.o
[ 33%] Building CXX object CMakeFiles/vertical-canvas.dir/sources-dock.cpp.o
[ 33%] Building CXX object CMakeFiles/vertical-canvas.dir/qt-display.cpp.o
[ 40%] Building CXX object CMakeFiles/vertical-canvas.dir/vertical-canvas.cpp.o
[ 53%] Building CXX object CMakeFiles/vertical-canvas.dir/vertical-canvas_autogen/mocs_compilation.cpp.o
[ 53%] Building CXX object CMakeFiles/vertical-canvas.dir/scenes-dock.cpp.o
[ 60%] Building CXX object CMakeFiles/vertical-canvas.dir/hotkey-edit.cpp.o
[ 66%] Building CXX object CMakeFiles/vertical-canvas.dir/config-dialog.cpp.o
[ 73%] Building CXX object CMakeFiles/vertical-canvas.dir/name-dialog.cpp.o
[ 80%] Building C object CMakeFiles/vertical-canvas.dir/audio-wrapper-source.c.o
[ 86%] Building C object CMakeFiles/vertical-canvas.dir/file-updater.c.o
[ 93%] Building CXX object CMakeFiles/vertical-canvas.dir/vertical-canvas_autogen/EWIEGA46WW/qrc_resources.cpp.o
In file included from /usr/include/obs/util/curl/curl-helper.h:19,
                 from /tmp/makepkg/obs-vertical-canvas/src/obs-vertical-canvas-1.1.0/file-updater.c:1:
In function ‘do_http_request’,
    inlined from ‘single_file_thread’ at /tmp/makepkg/obs-vertical-canvas/src/obs-vertical-canvas-1.1.0/file-updater.c:118:7:
/tmp/makepkg/obs-vertical-canvas/src/obs-vertical-canvas-1.1.0/file-updater.c:70:9: error: call to ‘_curl_easy_setopt_err_write_callback’ declared with attribute warning: curl_easy_setopt expects a curl_write_callback argument for this option [-Werror=attribute-warning]
   70 |         curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
      |         ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/vertical-canvas.dir/build.make:229: CMakeFiles/vertical-canvas.dir/file-updater.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/vertical-canvas.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

The plugin compiles and lets OBS start, but I haven’t actually tried the update functionality so not sure if this change in turn breaks this or not, and I don’t know C/++ well enough to spot off-hand that it does… but this at least makes it build.